### PR TITLE
Adding methods "errors" and "warnings"

### DIFF
--- a/lib/Bio/Tools/Primer3Redux/Result.pm
+++ b/lib/Bio/Tools/Primer3Redux/Result.pm
@@ -18,6 +18,8 @@ Bio::Tools::Primer3Redux::Result - Result class for Primer3 data
 
     # parse a Primer3 report, and get Bio::Tools::Primer3Redux::Result
     while (my $result = $parser->next_result) {
+        (say "primer design failed" and next) if $result->errors;
+         
         say $result->num_primer_pairs;
         my $pair = $result->next_primer_pair;
 
@@ -40,6 +42,14 @@ the end of a parse).
 To retrieve a sequence guaranteed to have all Primer/PrimerPair data
 attached, use get_processed_seq(). Switching seqs will cause a new batch of
 features to be generated and attached.
+
+Please note that primer3 does not terminate on errors during primer design 
+(e.g. due to input parameters that are impossible to fulfill).
+To check if errors or warnings were produced, it is recommended to always 
+check the result object for errors like so:
+if ($result->errors){
+  # handle the situation 
+}
 
 =head1 FEEDBACK
 
@@ -328,6 +338,39 @@ sub run_parameter {
     return unless defined $param && exists $self->{run_parameters}->{$param};
     return $self->{run_parameters}->{$param};
 }
+
+
+=head2 warnings
+ 
+ Title   : warnings
+ Function: returns a list of the warning messages returned by primer3, if any
+ Usage   : my @warnings = $obj->warnings;
+ Args    : none
+ Returns : Array of messages
+
+=cut
+
+sub warnings {
+  my $self = shift;
+  my $warning_value = $self->run_parameter('PRIMER_WARNING') || '';
+  return split(/;\s*/, $warning_value);
+} # warnings
+
+=head2 errors
+ 
+ Title   : errors
+ Function: returns a list of the error messages returned by primer3, if any
+ Usage   : my @errors = $obj->errors;
+ Args    : none
+ Returns : Array of messages
+
+=cut
+
+sub errors {
+  my $self = shift;
+  my $error_value = $self->run_parameter('PRIMER_ERROR') || '';
+  return split(/;\s*/, $error_value);
+} # errors
 
 =head2 rewind
 

--- a/t/Run/Primer3Redux.t
+++ b/t/Run/Primer3Redux.t
@@ -15,7 +15,7 @@ BEGIN {
 
     # num tests: see SKIP block for requires_executable
     # + 5 before the block
-    test_begin();
+    test_begin( -tests => 117,);
     use_ok('Bio::Tools::Run::Primer3Redux');
 }
 
@@ -95,6 +95,23 @@ my @tests = (
         }
     },
 
+  {
+    desc   => "pick PCR primers but cause warnings and error",
+    p3_version => 2,
+    params => {
+      'PRIMER_TASK'               => 'pick_pcr_primers',
+      'PRIMER_SALT_CORRECTIONS'   => 1,
+      'PRIMER_TM_FORMULA'         => 1,
+      'PRIMER_EXPLAIN_FLAG'       => 1,
+      'SEQUENCE_PRIMER'          => 'AAAAAAAAAAAAAAAAAAA', # this is not on the SEQUENCE_TEMPLATE, so will cause error
+    },
+    expect => { 
+#--------------------------------------------------
+#       warnings => 1,
+#-------------------------------------------------- 
+      errors => 1,
+    }
+  },
 );
 
 ok( $primer3 = Bio::Tools::Run::Primer3Redux->new(), "can instantiate object" );
@@ -130,6 +147,16 @@ SKIP: {
 
             while ( my $result = $parser->next_result ) {
                 isa_ok( $result, 'Bio::Tools::Primer3Redux::Result' );
+                my $expect_warnings = $test->{expect}{warnings};
+                SKIP:{
+                  skip ("test warnings if expectation defined",1) if !defined $expect_warnings;
+                  is ($result->warnings, $expect_warnings, "got the expected number of primer design warnings");
+                }
+                my $expect_errors = $test->{expect}{errors};
+                SKIP:{
+                  skip ("test errors if expectation defined",1) if !defined $expect_errors;
+                    is ($result->errors, $expect_errors, "got the expected number of primer design errors");
+                }
                 my $num_pairs = $test->{expect}{num_pairs};
                 is( $result->num_primer_pairs, $num_pairs,
                     "Got expected number of pairs: " . $num_pairs );
@@ -138,7 +165,7 @@ SKIP: {
 
                 SKIP: {
                     skip( "tests that require >0 primer pairs", 12 )
-                      if $result->num_primer_pairs == 0;
+                      if ! $result->num_primer_pairs;
                     my $pair = $result->next_primer_pair;
                     isa_ok( $pair, 'Bio::Tools::Primer3Redux::PrimerPair' );
                     isa_ok( $pair, 'Bio::SeqFeature::Generic' );
@@ -216,4 +243,3 @@ SKIP: {
 
 unlink('mlc') if -e 'mlc';
 
-done_testing();


### PR DESCRIPTION
I came across a problem when the module returned no primers but this was acutally due to incorrect input parameters. I think it shouldbe made easier to check the Primer3Redux::Result object for errors and warning emsages with two shortcut methods that access run_parameter('PRIMER_WARNING') and run_parameter('PRIMER_ERROR') and return arrays. I think it should be suggested to always check for such errors before retrieving any information from a result object.
I have added methods "errors" and "warnings", which makes it possible to do:
    die "this went wrong" if $results->errors;
or:
    print "these warnings were returned by primer3\n";
    print '- '.$_."\n" for $results->warnings;
