### PR TITLE
FEATURE: Primer3 v2.x.x tag support, updating default primer3 version

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -12,6 +12,7 @@ my $builder = Module::Build->new(
     },
     requires => {
         'Bio::Root::Version'   => '1.006.900',
+	'version'		=> '0.77',
     },
     recursive_test_files     => 1,
     add_to_cleanup      => [ 'Bio-Tools-Primer3Redux-*' ],

--- a/lib/Bio/Tools/Primer3Redux/Primer.pm
+++ b/lib/Bio/Tools/Primer3Redux/Primer.pm
@@ -86,6 +86,7 @@ use strict;
 # Object preamble - inherits from Bio::Root::Root
 
 use base qw(Bio::SeqFeature::Generic);
+our $AUTOLOAD;
 
 =head2 oligo_type
 
@@ -199,5 +200,32 @@ sub run_description {
     }
     $self->has_tag('explain') ? return ($self->get_tag_values('explain'))[0] : return;
 }
+
+=head2 AUTOLOAD
+ 
+ Title   : AUTOLOAD
+ Function: Used to access tags (properties) of the primer as given by primer3
+           Check the primer3 documentation for available output tags (in lower case)
+           For example, the priemr3 docs describe a tag
+           PRIMER_LEFT_X_SELF_ANY
+           that means you can do
+           my $selfbinding = $primer->self_any;
+ Usage   : my $hp = $primer->hairpin_th;
+           my $stab = $primer->end_stability;
+           etc.
+           see primer3 doc for available output tags
+ Args    : none
+ Returns : value for the requested tag, if tag is present, otherwise undef
+
+=cut
+
+sub AUTOLOAD {
+  my $self = shift;
+  my $type = ref($self) or $self->throw("$self is not an object");
+  my $name = $AUTOLOAD;
+  $name =~ s/.*://;
+  $self->has_tag($name) ? return ($self->get_tag_values($name))[0] : return;
+} # AUTOLOAD
+
 
 1;

--- a/lib/Bio/Tools/Run/Primer3Redux.pm
+++ b/lib/Bio/Tools/Run/Primer3Redux.pm
@@ -66,19 +66,6 @@ output files.
 
 This module a refactoring of the original BioPerl primer3 tools, themselves a
 refactoring of the original Primer3 module written by Rob Edwards. See
-my @ALLOWED_TASKS = qw(
-  pick_pcr_primers
-  pick_detection_primers
-  check_primers
-  pick_primer_list
-  pick_sequencing_primers
-  pick_cloning_primers
-  pick_discriminative_primers
-  pick_pcr_primers_and_hyb_probe
-  pick_left_only
-  pick_right_only
-  pick_hyb_probe_only
-);
 http://primer3.sourceforge.net for details and to download the software. This
 module should work for primer3 release 1 and above but is not guaranteed to work
 with earlier versions.

--- a/lib/Bio/Tools/Run/Primer3Redux.pm
+++ b/lib/Bio/Tools/Run/Primer3Redux.pm
@@ -145,10 +145,11 @@ use version;
 my $PROGRAMNAME = 'primer3_core';
 my %PARAMS;
 my @P1; #Parameters common for all 0.x and 1.x.x versions
-my @P11; #Parameters for the Santalucia Tm calculations in v1.1.0-v1.1.2
+my @P110; #Parameters for the Santalucia Tm calculations in v1.1.0-v1.1.2
 my @P2; #Parameters common for all 2.x.x versions
-my @P20; #2 Overlap parameters that only appears in v2.0.0
-my @P22; #New and changed parameters in v2.2.0 or above
+my @P200; #2 Overlap parameters that only appears in v2.0.0
+my @P220; #New and changed parameters in v2.2.0 or above
+my @P222; #2 more tags added in v2.2.2
 my @ALLOWED_TASKS;
 
 # 2.0 is still in alpha (3/3/10), so fallback to v1 for determining parameters
@@ -232,7 +233,7 @@ BEGIN {
     PRIMER_PAIR_MAX_TEMPLATE_MISPRIMING             PRIMER_PAIR_WT_TEMPLATE_MISPRIMING
 );
 
-@P11 = qw(
+@P110 = qw(
     PRIMER_TM_SANTALUCIA
     PRIMER_SALT_CORRECTIONS
    PRIMER_LOWERCASE_MASKING
@@ -379,12 +380,12 @@ BEGIN {
     P3_FILE_FLAG
     P3_COMMENT
 );
-@P20=qw(
+@P200=qw(
     SEQUENCE_PRIMER_OVERLAP_POS
     PRIMER_POS_OVERLAP_TO_END_DIST
 );
 
-@P22=qw(
+@P220=qw(
     SEQUENCE_OVERLAP_JUNCTION_LIST
     SEQUENCE_PRIMER_PAIR_OK_REGION_LIST
     PRIMER_MIN_3_PRIME_OVERLAP_OF_JUNCTION
@@ -416,6 +417,11 @@ BEGIN {
     PRIMER_INTERNAL_WT_TEMPLATE_MISHYB_TH
     PRIMER_PAIR_WT_TEMPLATE_MISPRIMING_TH
 
+);
+
+@P222 = qw (
+    PRIMER_MIN_LEFT_THREE_PRIME_DISTANCE
+    PRIMER_MIN_RIGHT_THREE_PRIME_DISTANCE
 );
 
 # These are the allowed values for PRIMER_TASK
@@ -495,9 +501,10 @@ sub new {
     #            map {$_ => $ct++} @P1;
 
     if ($v){
-        if ($v>=version->declare('2.2.0')){%PARAMS=map{$_ => $ct++} (@P2, @P22)}
-        elsif ($v>=version->declare('2.0.0')){%PARAMS=map{$_ => $ct++} (@P2, @P20)}
-        elsif ($v>=version->declare('1.1.0')) {%PARAMS=map{$_=> $ct++} (@P1, @P11);}
+        if ($v>=version->declare("2.2.2")){%PARAMS=map{$_ => $ct++} (@P2, @P220, @P222)}
+        elsif ($v>=version->declare('2.2.0')){%PARAMS=map{$_ => $ct++} (@P2, @P220)}
+        elsif ($v>=version->declare('2.0.0')){%PARAMS=map{$_ => $ct++} (@P2, @P200)}
+        elsif ($v>=version->declare('1.1.0')) {%PARAMS=map{$_=> $ct++} (@P1, @P110);}
         else {%PARAMS=map{$_ => $ct++} @P1;}
     }
 

--- a/t/Run/Primer3Redux.t
+++ b/t/Run/Primer3Redux.t
@@ -9,6 +9,7 @@ use warnings;
 use Data::Dumper;
 use Bio::Tools::Run::Primer3Redux;
 use Bio::SeqIO;
+use version;
 
 BEGIN {
     use Bio::Root::Test;
@@ -37,10 +38,12 @@ my $primer3_config_dir = 't/data/primer3_config/';
 # !!! When adding a new test, update the number of tests
 # to skip in the first SKIP block and in the BEGIN
 # block
+
+# Note p3_version is now a version.pm object, in line with Bio::Tools::Run::Primer3Redux::version.
 my @tests = (
   {
       desc       => "pick PCR primers with minimum product size range",
-      p3_version => 2,
+      p3_version => version->declare("2.0.0"),
       params     => {
           'PRIMER_TASK'               => 'pick_pcr_primers',
           'PRIMER_SALT_CORRECTIONS'   => 1,
@@ -57,7 +60,7 @@ my @tests = (
   {
       desc =>
         "pick PCR primers with minimum product size range (for primer3 v1)",
-      p3_version => 1,
+      p3_version => version->declare("1.0.0"),
       params     => {
           'PRIMER_TASK'               => 'pick_pcr_primers',
           'PRIMER_SALT_CORRECTIONS'   => 1,
@@ -72,7 +75,7 @@ my @tests = (
 
   {
       desc       => "make design fail due to very strict constraints",
-      p3_version => 2,
+      p3_version => version->declare("2.0.0"),
       params     => {
           'PRIMER_TASK'           => 'pick_pcr_primers',
           'PRIMER_MAX_POLY_X'     => 3,   # no runs of more than 2 of same nuc
@@ -86,8 +89,8 @@ my @tests = (
   },
 
   {
-      desc => "use PRIMER_PAIR_OK_REGION_LIST (new feature in primer3 v2.x)",
-      p3_version => 2,
+      desc => "use PRIMER_PAIR_OK_REGION_LIST (new feature in primer3 v2.2.x)",
+      p3_version => version->declare("2.2.0"), #This tag is only available for v2.2.0 or above
       params     => {
           'PRIMER_TASK'                         => 'pick_pcr_primers',
           'PRIMER_SALT_CORRECTIONS'             => 1,
@@ -95,7 +98,7 @@ my @tests = (
           'PRIMER_EXPLAIN_FLAG'                 => 1,
           'PRIMER_PRODUCT_MIN_TM'               => 60,
           'PRIMER_PRODUCT_SIZE_RANGE'           => '50-200',
-          'SEQUENCE_PRIMER_PAIR_OK_REGION_LIST' => '0,70,140,70',
+          'SEQUENCE_PRIMER_PAIR_OK_REGION_LIST' => '0,70,140,70', 
       },
       expect => {
           num_pairs => 5,
@@ -105,7 +108,7 @@ my @tests = (
 
   {
     desc   => "pick PCR primers but cause warnings and error",
-    p3_version => 2,
+    p3_version => version->declare("2.0.0"),
     params => {
       'PRIMER_TASK'               => 'pick_pcr_primers',
       'PRIMER_SALT_CORRECTIONS'   => 1,
@@ -120,7 +123,7 @@ my @tests = (
 
   {
     desc => "check existing primers without a sequence template. The primer ends are fully complementary but this is not picked up in this test because we are not using thermodynamic tests.",
-    p3_version => 2,
+    p3_version => version->declare("2.0.0"),
     run_without_seq_template => 1,
     params => {
       PRIMER_TASK=>'check_primers',
@@ -142,8 +145,9 @@ my @tests = (
     # and it should actually reject the primer pair but there
     # seems to be a bug in primer3 and the pair is not rejected
     # despite PRIMER_PAIR_COMPL_ANY_TH > PRIMER_PAIR_MAX_COMPL_ANY_TH
+    # This test limits to primer3 2.2.0 or above.
     desc => "check existing primers. Use thermodynamic parameters.",
-    p3_version => 2,
+    p3_version => version->declare("2.2.0"),
     run_without_seq_template => 1,
     params => {
       PRIMER_TASK=>'check_primers',
@@ -178,7 +182,7 @@ SKIP: {
 
     like( $primer3->program_name, qr/primer3/, 'program_name' );
     my $major_version;
-    if ( $primer3->version && $primer3->version =~ /^(\d+)/ ) {
+    if ( $primer3->version_check && $primer3->version_check->stringify =~ /^(\d+)/ ) {
         $major_version = $1;
         if ( $major_version < 2 ) {
             diag('++++++++++++++++++++++++++++++++++++++++++');
@@ -197,8 +201,9 @@ SKIP: {
         ok( $primer3 = Bio::Tools::Run::Primer3Redux->new() );
         my $required_version = $test->{p3_version} || 0;
         SKIP: {
-            skip( "tests for primer3 major version $required_version", 1 )
-              if $required_version != $major_version;
+            #Refined version check to deal with some tests that would require primer3 2.2.0 or above.
+            skip( "tests for primer3 version $required_version", 1 )
+              if ((($required_version>=version->declare("2.0.0"))&&($primer3->version_check<$required_version))||(($required_version<version->declare("2.0.0"))&&($required_version != $primer3->version_check)));
 
             # This tests the new API with dedicated run methods
             # for each primer task, so remove PRIMER_TASK from params

--- a/t/Run/Primer3Redux.t
+++ b/t/Run/Primer3Redux.t
@@ -39,7 +39,7 @@ my $primer3_config_dir = 't/data/primer3_config/';
 # to skip in the first SKIP block and in the BEGIN
 # block
 
-# Note p3_version is now a version.pm object, in line with Bio::Tools::Run::Primer3Redux::version.
+# Note p3_version is now a version.pm object, in line with Bio::Tools::Run::Primer3Redux::version_check.
 my @tests = (
   {
       desc       => "pick PCR primers with minimum product size range",

--- a/t/Run/Primer3Redux.t
+++ b/t/Run/Primer3Redux.t
@@ -15,7 +15,7 @@ BEGIN {
 
     # num tests: see SKIP block for requires_executable
     # + 5 before the block
-    test_begin( -tests => 164);
+    test_begin( -tests => 188);
 
     # this is run in 00-compile.t
     #use_ok('Bio::Tools::Run::Primer3Redux');
@@ -172,7 +172,7 @@ ok( $primer3 = Bio::Tools::Run::Primer3Redux->new(), "can instantiate object" );
 
 SKIP: {
     test_skip(
-        -tests               => 163,
+        -tests               => 184,#163,
         -requires_executable => $primer3,
     );
 
@@ -256,8 +256,22 @@ SKIP: {
                       cmp_ok( $rp->seq->length, '>', 18,
                           "rev primer length >18" );
 
+                      # these properties are implemented specifically in the 
+                      # Primer object
                       cmp_ok( $primer->gc_content,   '>', 40, 'GC content >40' );
                       cmp_ok( $primer->melting_temp, '>', 50, 'Tm > 50' );
+                      
+                      # these properties are from auto-generated accessors
+                      # in the Primer object - we have one for each output
+                      # tag returned by primer3 (lower case)
+                      like( $primer->sequence,  qr/^[ACGTN]+$/, "The sequence of the primer can also be accessed via the SEQUENCE tag");
+                      if ( $test->{params}{PRIMER_THERMODYNAMIC_ALIGNMENT} ){
+                        like( $primer->self_any_th, qr/-?\d+(\.\d+)?/, "value from self-end tag is a number");
+                      } else {
+                        like( $primer->self_any, qr/-?\d+(\.\d+)?/, "value from self-end tag is a number");
+                      }
+                      is( $primer->tm, $primer->melting_temp, "the auto-generated method to access the value of tag TM returns the same as the 'meting_temp' method");
+
                       is( $primer->rank,       0, 'rank of the first primer is 0' );
                       like( $primer->run_description, qr/considered/, "The primer's description contain the word 'considered'" );
                     }


### PR DESCRIPTION
1. Added tag sets for most Peimer3 versions between 2.0.0 to 2.3.7. To avoid inflating file size, the tag sets for each version were generated in an incremental manner.
1. The default Primer3 version is changed to 2.2.3.
1. Primer3 version management is handled by `qv` instead of regex for easier processing.